### PR TITLE
Removed verbose versions of “checked” and “disabled” attributes

### DIFF
--- a/src/resources/views/components/checkbox.blade.php
+++ b/src/resources/views/components/checkbox.blade.php
@@ -14,11 +14,11 @@
     <input 
         value="{{$value}}" 
         name="{{$name}}"
-        @if($disabled=='true') disabled="disabled" @endif
+        @if($disabled=='true') disabled @endif
         class="text-blue-500 
             w-5 h-5 mr-2 disabled:opacity-60
             focus:ring-blue-400 focus:ring-opacity-25 
             border border-gray-300 bw-checkbox 
             rounded" 
-        type="{{$type}}" @if($checked == 'true') checked="checked" @endif />{!! $label !!}
+        type="{{$type}}" @if($checked == 'true') checked @endif />{!! $label !!}
 </label>  &nbsp; &nbsp;

--- a/src/resources/views/components/toggle.blade.php
+++ b/src/resources/views/components/toggle.blade.php
@@ -7,9 +7,9 @@
     // position of the label above.. left or right
     'label_position' => 'left',
     'labelPosition' => 'left',
-    // sets or unsets disabled="disabled" on the toggle element
+    // sets or unsets disabled on the toggle element
     'disabled' => 'false',
-    // sets or unsets checked="checked" on the toggle element
+    // sets or unsets checked on the toggle element
     'checked' => 'false',
     // background color to display when toggle is active
     'color' => 'blue',
@@ -31,7 +31,7 @@
 
 <label class="relative @if($justified=='false')inline-flex @else flex justify-between @endif items-center group" onclick="{!!$onclick!!}">
     @if($label_position == 'left' && $label !== '')<span class="pr-4 {{$class}}">{!!$label!!}</span>@endif
-    <input type="checkbox" name="{{$name}}" @if($checked=='true')checked="checked"@endif @if($disabled=='true')disabled="disabled"@endif class="absolute left-1/2 -translate-x-1/2 w-full h-full peer appearance-none rounded-md" />
+    <input type="checkbox" name="{{$name}}" @if($checked=='true')checked@endif @if($disabled=='true')disabled@endif class="absolute left-1/2 -translate-x-1/2 w-full h-full peer appearance-none rounded-md" />
     <span style="zoom: 80%" class="w-20 @if($bar=='thick')h-10 @else h-5 @endif flex items-center flex-shrink-0 p-1 bg-gray-300 rounded-full duration-300 ease-in-out 
                 peer-disabled:opacity-40 @if($color=='red')peer-checked:bg-red-500/80 @endif @if($color=='yellow')peer-checked:bg-yellow-500/80 @endif @if($color=='green')peer-checked:bg-green-500/80 @endif @if($color=='pink')peer-checked:bg-pink-500/80 @endif @if($color=='cyan')peer-checked:bg-cyan-500/80 @endif @if($color=='gray')peer-checked:bg-slate-500 @endif @if($color=='purple')peer-checked:bg-purple-500/80 @endif @if($color=='orange')peer-checked:bg-orange-500/80 @endif @if($color=='blue')peer-checked:bg-blue-500/80 @endif after:w-8 after:h-8 after:bg-white after:rounded-full after:shadow-md after:duration-300 
                 peer-checked:after:translate-x-10 group-hover:after:translate-x-0"></span>


### PR DESCRIPTION
Hi,

I removed all occurences of the verbose versions of the "checked" and "disabled" attributes. There is no benefit to using `disabled="disabled"` and `checked="checked"` over the short version.