### PR TITLE
Fixed button not using secondary color

### DIFF
--- a/resources/views/components/button/index.blade.php
+++ b/resources/views/components/button/index.blade.php
@@ -31,8 +31,8 @@
     // available options are a, button
     'tag' => 'button',
 
-    // red, yellow, green, blue, purple, orange, cyan, black
-    'color' => 'primary',
+    // primary, secondary, red, yellow, green, blue, purple, orange, cyan, black
+    'color' => '',
 
     // overwrite the button text color
     'button_text_css' => '',
@@ -61,6 +61,7 @@
     // css for the various colours
     'colours'       => [
         'primary'   => '!bg-primary-500 focus:ring-primary-500/70 hover:!bg-primary-700 active:!bg-primary-700 %s',
+        'secondary' => '!bg-secondary-500 focus:ring-secondary-500/70 hover:!bg-secondary-700 active:!bg-secondary-700 %s',
         'red'       => '!bg-red-500 focus:ring-red-500 hover:!bg-red-700 active:!bg-red-700 %s',
         'yellow'    => '!bg-yellow-500 focus:ring-yellow-500 hover:!bg-yellow-700 active:!bg-yellow-700 %s',
         'green'     => '!bg-green-500 focus:ring-green-500 hover:!bg-green-700 active:!bg-green-700 %s',
@@ -88,13 +89,14 @@
     if($canSubmit) $can_submit = $canSubmit;
     if(!$showFocusRing) $show_focus_ring = $showFocusRing;
 
+	$color = (!empty($color)) ? $color : $type;
     $button_type = ($can_submit) ? 'submit' : 'button';
     $spinner_css = (!$show_spinner) ? 'hidden' : '';
     $focus_ring_css = (!$show_focus_ring) ? 'focus:!ring-0' : 'focus:!ring';
-    $primary_colour_css = ($type == 'primary') ? sprintf($colours[$color],$focus_ring_css) : '';
+    $primary_colour_css = sprintf($colours[$color],$focus_ring_css);
     $radius_css = $roundness[$radius] ?? 'rounded-full';
     $button_text_css = (!empty($buttonTextCss)) ? $buttonTextCss : $button_text_css;
-    $button_text_colour = $button_text_css ?? ($type === 'primary' ? 'text-white hover:text-white' : 'text-black hover:text-black');
+    $button_text_colour = (!empty($button_text_css)) ? $button_text_css : 'text-white hover:text-white';
     $disabled_css = $disabled ? 'disabled' : 'cursor-pointer';
     $tag = ($tag !== 'a' && $tag !== 'button') ? 'button' : $tag;
     $merged_attributes = $attributes->merge(['class' => "bw-button $size $type $name $primary_colour_css $disabled_css $radius_css"]);


### PR DESCRIPTION
# Issue
This pull request was made due to having issues with
the secondary button not using the secondary color specified in my tailwind.config.js file.

# Changes
- Removed the black text in the secondary color, as its background color is often gray (it was before the changes), and thus made it less difficult to read text.
Moreover, all buttons have white text, except the secondary button, which made it feel odd.
- Added the 'secondary' color option, and set the default color to the type of the button instead.
- Removed a null coalescing operator that never returned false. It's at the line with the `$button_text_colour` variable assignment. `$button_text_css` is never null, but `""` by default.

# After those changes
The secondary button is now readable, and follows the color specified in tailwind.config.js, as written in the bladewind documentation.

# About the button types
Since changing the button types actually just changes their color, I do not see why the `$type` prop exists. Why not just using `primary` and `secondary` in the `color` prop, since they are already there? What is the difference between a primary red button, and a secondary red button?

I did not remove the `type` prop, as it is not a bug, and could break legacy code using bladewind, but I would propose to think of deprecating it, at least if I am correct in my reasoning.

# Further contribution
I may create other pull requests in the future.
Could you maybe explain me how I can include bladewind in my laravel project from source? So that I can directly modify it in my project, see the results, and push them on my fork.

That would make my contribution process much faster.

Thank you for considering this pull request.
