### PR TITLE
#Issue-315, Fixed: Textarea toolbar not sending through value on form submission.

### DIFF
--- a/resources/views/components/textarea.blade.php
+++ b/resources/views/components/textarea.blade.php
@@ -49,7 +49,7 @@
 <div class="relative w-full @if($add_clearing) mb-3 @endif">
     @if($toolbar)
         <div id="{{$name}}">{{$selected_value}}</div>
-        <input type="hidden" name="{{ $name }}" id="{{ $name }}-hidden" value="">
+        <textarea hidden name="{{ $name }}" id="{{ $name }}-hidden" class="size-0"></textarea>
     @else
         <textarea {{ $attributes->merge(['class' => "bw-input peer $is_required $name $placeholder_color"]) }}
                   id="{{ $name }}"

--- a/resources/views/components/textarea.blade.php
+++ b/resources/views/components/textarea.blade.php
@@ -49,6 +49,7 @@
 <div class="relative w-full @if($add_clearing) mb-3 @endif">
     @if($toolbar)
         <div id="{{$name}}">{{$selected_value}}</div>
+        <input type="hidden" name="{{ $name }}" id="{{ $name }}-hidden" value="">
     @else
         <textarea {{ $attributes->merge(['class' => "bw-input peer $is_required $name $placeholder_color"]) }}
                   id="{{ $name }}"
@@ -116,6 +117,12 @@
         } else {
             quillOptions.modules.toolbar = modifyToolbarOptions(toolbarOptions, '{{$except}}');
             var quill_{{$name}} = new Quill('#{{$name}}', quillOptions);
+
+            // Update the hidden input field whenever the textarea content changes
+            quill_{{ $name }}.on('text-change', function(delta, oldDelta, source) {
+                var value = quill_{{ $name }}.root.innerHTML;
+                document.getElementById('{{ $name }}-hidden').value = value;
+            });
         }
     </script>
 @endif


### PR DESCRIPTION
The issue occurs because when the toolbar attribute is set to true, the component renders a `<div>` instead of a `<textarea>`. Since the `<div>` element doesn't support a `"name"` attribute (which is required for form submissions), so the form data is not being sent as expected.

I resolve this, by using a hidden input field that carries the name attribute and holds the content of the Quill editor by some JS modifications.

Thank you.