### PR TITLE
fix: load javascript from public path

### DIFF
--- a/resources/views/components/dropmenu.blade.php
+++ b/resources/views/components/dropmenu.blade.php
@@ -60,7 +60,7 @@
 </div>
 
 <script>
-    @php include_once('vendor/bladewind/js/dropmenu.js'); @endphp
+    @php include_once(public_path('vendor/bladewind/js/dropmenu.js')); @endphp
 </script>
 <script @if($modular) type="module" @endif>
     const {{ $name }} = new BladewindDropmenu('{{ $name }}', {

--- a/resources/views/components/notification.blade.php
+++ b/resources/views/components/notification.blade.php
@@ -26,5 +26,5 @@
 </div>
 
 <script>
-    @php include_once('vendor/bladewind/js/notification.js'); @endphp
+    @php include_once(public_path('vendor/bladewind/js/notification.js')); @endphp
 </script>

--- a/resources/views/components/select.blade.php
+++ b/resources/views/components/select.blade.php
@@ -229,7 +229,7 @@
 </div>
 
 <script>
-    @php include_once('vendor/bladewind/js/select.js'); @endphp
+    @php include_once(public_path('vendor/bladewind/js/select.js')); @endphp
 </script>
 <script @if($modular) type="module" @endif>
     const bw_{{ $input_name }} = new BladewindSelect('{{ $input_name }}', '{{ $placeholder }}');


### PR DESCRIPTION
Set javascript files to always load from public path, so that tests loads them from the correct path. 

Fixes #147 