### PR TITLE
feat: support for different notification sizes

### DIFF
--- a/public/js/notification.js
+++ b/public/js/notification.js
@@ -8,7 +8,7 @@ class BladewindNotification {
     timeoutName;
     colours;
 
-    constructor(title, message, type, dismissInMinutes) {
+    constructor(title, message, type, dismissInMinutes, size) {
         this.title = title || '';
         this.message = message || '';
         this.type = type || 'success';
@@ -22,6 +22,13 @@ class BladewindNotification {
             "warning": {"border": "border-yellow-500/50", "bg": "bg-amber-200/80"},
             "info": {"border": "border-blue-500/50", "bg": "bg-blue-200/80"},
         };
+        this.size = size || 'regular'
+        this.sizes = {
+            "small": {"container": "sm:!max-w-[350px]", "modal_icon": "!size-10", "close": "size-6", "heading": "text-base", "message": "text-sm"},
+            "regular": {"container": "sm:!max-w-[450px]", "modal_icon": "!size-14", "close": "size-6", "heading": "text-lg", "message": "text-sm"},
+            "big": {"container": "sm:!max-w-[550px]", "modal_icon": "!size-16", "close": "size-6", "heading": "text-3xl", "message": "text-base"}
+        }
+        this.setContainerSize()
     }
 
     show = () => {
@@ -47,27 +54,32 @@ class BladewindNotification {
         });
     }
 
+    setContainerSize = () => {
+        changeCss('.bw-notification-container', this.sizes[this.size].container, 'add');
+    }
+
     modalIcon = () => {
+        changeCss(`.bw-notification-icons .${this.type}`, this.sizes[this.size].modal_icon, 'add');
         changeCss(`.bw-notification-icons .${this.type}`, 'hidden', 'remove');
         return dom_el(`.bw-notification-icons .${this.type}`).outerHTML.replaceAll('[type]', this.typeColour(this.type));
     }
 
     template = () => {
-        return `<div class="flex border-l-[6px] border-opacity-80 ${this.name} border-${this.typeColour(this.type)}-500 
+        return `<div class="flex border-l-[6px] border-opacity-80 ${this.name} border-${this.typeColour(this.type)}-500
                 bg-white dark:bg-dark-800/95 shadow dark:shadow-slate-800/50 p-4 rounded-lg mb-3">
             <div class="pr-4 grow-0">${this.modalIcon()}</div>
             <div class="pb-1 pr-4 relative grow">
-                <h1 class="font-semibold text-gray-700 dark:text-slate-300">${this.title}</h1>
-                <div class="pt-1 text-sm !text-gray-600 dark:!text-slate-400 message">${this.message}</div>
+                <h1 class="font-semibold text-gray-700 dark:text-slate-300 ${this.sizes[this.size].heading}">${this.title}</h1>
+                <div class="pt-1 !text-gray-600 dark:!text-slate-400 message ${this.sizes[this.size].message}">${this.message}</div>
                 ${this.closeIcon()}
             </div>
         </div>`;
     }
 
     closeIcon = () => {
-        return `<svg xmlns="http://www.w3.org/2000/svg" class="close size-5 absolute -right-1 cursor-pointer 
-                    -top-1 text-gray-400 hover:bg-gray-200 hover:rounded-full dark:hover:bg-slate-900 p-1" fill="none" 
-                    viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" 
+        return `<svg xmlns="http://www.w3.org/2000/svg" class="close ${this.sizes[this.size].close} absolute -right-1 cursor-pointer
+                    -top-1 text-gray-400 sm:!max-w-[350px] hover:bg-gray-200 hover:rounded-full dark:hover:bg-slate-900 p-1" fill="none"
+                    viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round"
                     stroke-width="3" d="M6 18L18 6M6 6l12 12" /></svg>`;
     }
 
@@ -83,6 +95,6 @@ class BladewindNotification {
 
 }
 
-var showNotification = (title, message, type, dismiss_in) => {
-    new BladewindNotification(title, message, type, dismiss_in).show();
+var showNotification = (title, message, type, dismiss_in, size) => {
+    new BladewindNotification(title, message, type, dismiss_in, size).show();
 }

--- a/resources/views/components/notification.blade.php
+++ b/resources/views/components/notification.blade.php
@@ -9,14 +9,14 @@
         'bottom_right' => 'right-4 bottom-10',
         'bottom_center' => 'bottom-10', // FIXME::
         'bottom_left' => 'left-4 bottom-10',
-    ]
+    ],
 ])
 @php
     // [type] is replaced with the type of notification in notification.js
-    $css = "!size-14 p-2 rounded-full bg-[type]-200/80 dark:bg-[type]-600 text-[type]-600 dark:text-[type]-100";
+    $css = " p-2 rounded-full bg-[type]-200/80 dark:bg-[type]-600 text-[type]-600 dark:text-[type]-100";
     $position = str_replace(' ', '_', $position);
 @endphp
-<div class="fixed flex flex-col-reverse {{ $position_css[str_replace('-', '_', $position)] }} z-50 bw-notification-container w-11/12 sm:!max-w-[450px]"></div>
+<div class="fixed flex flex-col-reverse {{ $position_css[str_replace('-', '_', $position)] }} z-50 bw-notification-container w-11/12"></div>
 {{--sm:w-1/4 sm:w-96 md:w-96  w-11/12--}}
 <div class="bw-notification-icons hidden">
     <x-bladewind::modal-icon class="hidden {{$css}}"/>


### PR DESCRIPTION
We desired a different size for our notification. So made a proposition for supporting that.

Notice that I've moved the width and icon size over to `notification.js`, from the blade component file. This lets you set the size on the fly when you are calling the notification, if you would like different sizes cross your project.

Currently supports `small`, `regular`(default) and `big`.