### PR TITLE
Optimize table search for large datasets

### DIFF
--- a/public/js/helpers.js
+++ b/public/js/helpers.js
@@ -516,17 +516,74 @@ var togglePassword = (element, mode) => {
 }
 
 /**
+ * Partition an array into two separate arrays.
+ * @param {array} arr - The array to be split.
+ * @param {function} fn - The evaluation function to run on each element > should return true/false for each element
+ * @return {[array, array]}
+ */
+const partition = (arr, fn) => {
+    return arr.reduce(
+      (acc, val, i, arr) => {
+        acc[fn(val, i, arr) ? 0 : 1].push(val);
+        return acc;
+      },
+      [[], []]
+    );
+}
+
+/**
  * Filter a table based on keyword.
  * @param {string} keyword - The keyword to filter table by.
  * @param {string} table - The css class (name) of the table to filter.
+ * @param {string} field - The field to search.
  * @return {void}
  */
-var filterTable = (keyword, table) => {
-    domEls(`${table} tbody tr`).forEach((tr) => {
-        (tr.innerText.toLowerCase().includes(keyword.toLowerCase())) ?
-            unhide(tr, true) : hide(tr, true);
+var filterTable = (keyword, table, field) => {
+    const [showList, hideList] = partition(tableData, (row) => {
+        if (field){
+            return row[field].toLowerCase().match(keyword.toLowerCase());
+        } else {
+            return Object.values(row).toString().match(keyword.toLowerCase());
+        }
+    });
+
+    hideList.forEach( (row) => {
+        hide(domEl(`${table} tbody tr[data-id='${row.id}']`), true);
+    });
+    showList.forEach( (row) => {
+        const elem = domEl(`${table} tbody tr[data-id='${row.id}'].hidden`);
+        if (elem){
+            unhide(elem, true);
+        }
     });
 }
+
+/**
+ * Filter a table based on keyword, .
+ * @param {string} keyword - The keyword to filter table by.
+ * @param {string} table - The css class (name) of the table to filter.
+ * @param {string} field - The field to search.
+ * @param {int} delay - Number of milliseconds to debouce the search.
+ * @return {function} - The debounced search function to be run
+ */
+let debounceTimerId;
+const filterTableDebounced = (keyword, table, field = null, delay = 0, minLength = 0) => {
+    if (keyword.length >= minLength) {
+        return (...args) => {
+            clearTimeout(debounceTimerId);
+            debounceTimerId = setTimeout( () => filterTable(keyword, table, field), delay);
+        };
+    } else {
+        return (...args) => {
+            clearTimeout(debounceTimerId);
+            debounceTimerId = setTimeout( () => {
+                document.querySelectorAll(`${table} tbody tr.hidden`).forEach((tr) => {
+                    unhide(tr, true);
+                });}, delay);
+        };
+    }
+};
+
 
 /**
  * Select a tag.


### PR DESCRIPTION
The filterTable function for searchable tables has been optimized for searching large datasets by storing the $data array into a JavaScript variable, then filtering that array for relevant records, then applying required DOM updates, as opposed to using the DOM as the original list to search.

Implemented 3 new props to assist in other optimizations for the search:
- search_field (string: default null) > limit the search to a particular property/key
- search_min_length (integer: default 0) > number of characters required in search field before performing a search. If 0 or search value length < this value, all rows will be left visible
- search_debounce (integer: default 0) > number of milliseconds to wait after an input event in the search box before performing a search

To perform the DOM updates, each row required a unique ID, so this update also now ensures that each row in the $data array has an 'id' value set.