### PR TITLE
Fixes #393

### DIFF
--- a/resources/views/components/select.blade.php
+++ b/resources/views/components/select.blade.php
@@ -245,7 +245,8 @@
     </div>
     <input type="hidden" name="{{ ($data_serialize_as !== '') ? $data_serialize_as : $input_name }}"
            class="bw-{{$input_name}} @if($required) required @endif"
-           @if($required) data-parent="bw-select-{{$input_name}}" @endif />
+           @if($required) data-parent="bw-select-{{$input_name}}" @endif
+           @if($multiple) autocomplete="off" @endif />
 </div>
 
 <script>


### PR DESCRIPTION
Description:
Firefox is trying to be helpful with autocomplete when refreshing page, causing the hidden input to be non-empty before script initialization. This confuses select.js, particularly around those lines: 
https://github.com/mkocansey/bladewind/blob/4cf1c89ed1c82f9dc6280f0807be7f610cb9ea63/public/js/select.js#L188-L189

Fix: disable autocomplete explicitly