### PR TITLE
Replace table-icons with Bladewind component

### DIFF
--- a/resources/views/components/table.blade.php
+++ b/resources/views/components/table.blade.php
@@ -255,7 +255,7 @@
                                     @foreach($tableHeadings as $th)
                                         <td data-row-id="{{ $row_id }}" data-column="{{ $th }}">{!! $row[$th] !!}</td>
                                     @endforeach
-                                    <table-icons :icons_array="$iconsArray" :row="$row"/>
+                                    <x-bladewind::table-icons :icons_array="$iconsArray" :row="$row"/>
                                 </tr>
                             @endforeach
                         @endforeach
@@ -279,7 +279,7 @@
                                         data-column="{{ $th }}">{!! $row[$th] !!}</td>
                                     {{--                                    @endif--}}
                                 @endforeach
-                                <table-icons :icons_array="$iconsArray" :row="$row"/>
+                                <x-bladewind::table-icons :icons_array="$iconsArray" :row="$row"/>
                             </tr>
                         @endforeach
                     @endif


### PR DESCRIPTION
Updated the table to use the <x-bladewind::table-icons> component instead of the custom <table-icons> tag for rendering icons. This change improves consistency and leverages the Bladewind UI library.