### PR TITLE
[v3.1.2] Merge development --> main

### DIFF
--- a/resources/views/components/table.blade.php
+++ b/resources/views/components/table.blade.php
@@ -255,7 +255,7 @@
                                     @foreach($tableHeadings as $th)
                                         <td data-row-id="{{ $row_id }}" data-column="{{ $th }}">{!! $row[$th] !!}</td>
                                     @endforeach
-                                    <table-icons :icons_array="$iconsArray" :row="$row"/>
+                                    <x-bladewind::table-icons :icons_array="$iconsArray" :row="$row"/>
                                 </tr>
                             @endforeach
                         @endforeach
@@ -279,7 +279,7 @@
                                         data-column="{{ $th }}">{!! $row[$th] !!}</td>
                                     {{--                                    @endif--}}
                                 @endforeach
-                                <table-icons :icons_array="$iconsArray" :row="$row"/>
+                                <x-bladewind::table-icons :icons_array="$iconsArray" :row="$row"/>
                             </tr>
                         @endforeach
                     @endif


### PR DESCRIPTION
This pull request updates the `resources/views/components/table.blade.php` file to replace the usage of the `table-icons` component with the `x-bladewind::table-icons` component. This change ensures consistency by using the Bladewind UI library's table icons component.

Key changes:

* Replaced `<table-icons>` with `<x-bladewind::table-icons>` for rendering table icons, ensuring compatibility with the Bladewind UI library. (`[[1]](diffhunk://#diff-cd6858667f064265a9b0ae454f872c370ecb24b183e3916b7f1f70245edc8824L258-R258)`, `[[2]](diffhunk://#diff-cd6858667f064265a9b0ae454f872c370ecb24b183e3916b7f1f70245edc8824L282-R282)`)