### PR TITLE
Filepond register image plugins only if hasImageFiles is true

### DIFF
--- a/resources/views/components/filepicker.blade.php
+++ b/resources/views/components/filepicker.blade.php
@@ -175,14 +175,16 @@
     let cropper;
 @endonce @endif
     FilePond.registerPlugin(
-        FilePondPluginImageExifOrientation,
         FilePondPluginFileValidateSize,
         FilePondPluginFileValidateType,
+        @if($hasImageFiles)
+        FilePondPluginImageExifOrientation,
         FilePondPluginImageValidateSize,
         FilePondPluginImagePreview,
-        @if($canCrop)FilePondPluginImageCrop,@endif
         FilePondPluginImageResize,
         FilePondPluginImageTransform,
+        @if($canCrop)FilePondPluginImageCrop,@endif
+        @endif
         @if($base64)FilePondPluginFileEncode,@endif
     );
 const pond_{{$cleanName}} = FilePond.create(domEl('input[name="{{$name}}"]'), {


### PR DESCRIPTION
This fixes an issue where the FilePond.registerPlugin function fails if the acceptedFileTypes prop doesn't specify that image files are allowed, e.g. only '.csv' or '.xlsx'