### PR TITLE
fix: prevent filter() from resetting source select value

### DIFF
--- a/public/js/select.js
+++ b/public/js/select.js
@@ -413,7 +413,6 @@
                 this.filterBy = by;
                 this.skipReset = skipReset;
                 if (by !== '') {
-                    this.reset();
                     domEls(this.strSelectItems(this.toFilter, `:not(.empty-state)`)).forEach((el) => {
                         const filterValue = el.getAttribute('data-filter-value');
                         (filterValue === by) ? unhide(el, true) : hide(el, true);


### PR DESCRIPTION
Fixes #543

Remove this.reset() call in filter() method that was incorrectly clearing the source select's value when filtering a target select.