### PR TITLE
Fix issue #546 on pass table row value to modal

### DIFF
--- a/resources/views/components/table.blade.php
+++ b/resources/views/components/table.blade.php
@@ -139,7 +139,13 @@
             $actionArray = explode('|',$action);
             $tempActionsArray = [];
             foreach($actionArray as $this_action){
-                $action_str_to_arr = explode(':', $this_action);
+                /*
+                * Fix: Ensure correct splitting of action string for modal placeholder syntax.
+                * Previously, explode(':', $this_action) could split into more than two parts
+                * when colons appeared inside parameters, e.g. showModal('modal', {key: '{data-key}'}).
+                * Now, explode(':', $this_action, 2) limits the split to two parts, preserving existing behavior.
+                */
+                $action_str_to_arr = explode(':', $this_action, 2);
                 $tempActionsArray[trim($action_str_to_arr[0])] = trim($action_str_to_arr[1]);
             }
             $iconsArray[] = $tempActionsArray;


### PR DESCRIPTION
This fixes issue #546, where table row values cannot be passed to modal placeholders.

Now this example code works:
```php
$action_icons = [
    "icon:pencil | tip:edit | click:editItem('{slug}')",
    "icon:trash | color:red | tip:delete | click:showModal('delete-item', {slug: '{slug}'})",
];
```
