### PR TITLE
Development into main

### DIFF
--- a/config/bladewind.php
+++ b/config/bladewind.php
@@ -69,7 +69,7 @@ return [
     */
     'button' => [
         'size' => 'regular',
-        'radius' => 'full',
+        'radius' => 'small',
         'show_focus_ring' => true,
         'tag' => 'button',
         'icon_right' => false,


### PR DESCRIPTION
This pull request makes a minor update to the default button configuration in the `config/bladewind.php` file. The default border radius for buttons is changed from `full` to `small`. 

- Changed the default value of the `radius` property for buttons from `full` to `small` in `config/bladewind.php`