### PR TITLE
Prevent showing an empty asterisk when an explicit empty placeholder is set

### DIFF
--- a/resources/views/components/input.blade.php
+++ b/resources/views/components/input.blade.php
@@ -123,7 +123,7 @@
     $clearable = parseBladewindVariable($clearable);
     $enforce_limits = parseBladewindVariable($enforceLimits);
 
-    $required_symbol = ($label == '' && $required) ? ' *' : '';
+    $required_symbol = ($label == '' && $placeholder != '' && $required) ? ' *' : ''; 
     $is_required = ($required) ? 'required' : '';
     $placeholder_color = ($show_placeholder_always || $label == '') ? '' : 'placeholder-transparent dark:placeholder-transparent';
     $placeholder_label = ($show_placeholder_always) ? $placeholder : (($label !== '') ? $label : $placeholder);

--- a/resources/views/components/input.blade.php
+++ b/resources/views/components/input.blade.php
@@ -123,7 +123,7 @@
     $clearable = parseBladewindVariable($clearable);
     $enforce_limits = parseBladewindVariable($enforceLimits);
 
-    $required_symbol = ($label == '' && $placeholder != '' && $required) ? ' *' : ''; 
+    $required_symbol = ($label == '' && $placeholder != '' && $required) ? ' *' : '';
     $is_required = ($required) ? 'required' : '';
     $placeholder_color = ($show_placeholder_always || $label == '') ? '' : 'placeholder-transparent dark:placeholder-transparent';
     $placeholder_label = ($show_placeholder_always) ? $placeholder : (($label !== '') ? $label : $placeholder);


### PR DESCRIPTION
I'm running into an issue where an asterisk is always shown as a placeholder when the input field is required. Even when an explicit empty placeholder is set. To fix this, add a conditional check for an empty placeholder.